### PR TITLE
fix: correct CI workflow to trigger production deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ "main", "development" ]
+    branches: ["development"]  # Main is protected, only accepts PRs
     tags:
       - 'v*'
   pull_request:
-    branches: [ "development" ]
+    branches: ["main", "development"]
 
 jobs:
   build-and-test:
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     
     - name: Install Node.js
       uses: actions/setup-node@v4
@@ -43,15 +45,25 @@ jobs:
       id: version
       run: |
         if [[ $GITHUB_REF == refs/tags/* ]]; then
+          # For production tags (v*)
           VERSION=${GITHUB_REF#refs/tags/}
+        elif [[ $GITHUB_REF == refs/heads/main ]]; then
+          # For main branch (via PR merge), create RC tag with commit hash
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          VERSION="${LAST_TAG%-*}-rc.${COMMIT_HASH}"
+          # Create and push RC tag
+          git tag $VERSION
+          git push origin $VERSION
         else
+          # For development and other branches
           VERSION=$(git rev-parse --short HEAD)
         fi
         echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-    # Upload para o Nexus apenas se não for a branch main
+    # Upload to Nexus except for PRs
     - name: Upload to Nexus
-      if: github.ref != 'refs/heads/main'
+      if: github.event_name != 'pull_request'
       env:
         NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
       run: |
@@ -59,10 +71,10 @@ jobs:
           --upload-file build.zip \
           "https://pkg.rumblersoppa.com.br/repository/raw-hosted/rumbler-portfolio/${{ steps.version.outputs.version }}/build.zip"
 
-  # Deploy para desenvolvimento apenas se for branch development ou PR para development
+  # Deploy to development only on push to development branch
   call-development-deploy:
     needs: build-and-test
-    if: (github.ref == 'refs/heads/development' || github.event_name == 'pull_request') && github.ref != 'refs/heads/main'
+    if: github.ref == 'refs/heads/development' && github.event_name == 'push'
     uses: ./.github/workflows/development.yml
     with:
       version: ${{ needs.build-and-test.outputs.version }}
@@ -70,7 +82,18 @@ jobs:
       nexus_username: ${{ secrets.NEXUS_USERNAME }}
       nexus_password: ${{ secrets.NEXUS_PASSWORD }}
 
-  # Deploy para produção apenas se for uma tag
+  # Deploy to release only after PR merge to main
+  call-release-deploy:
+    needs: build-and-test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ needs.build-and-test.outputs.version }}
+    secrets:
+      nexus_username: ${{ secrets.NEXUS_USERNAME }}
+      nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+
+  # Deploy to production only on version tags
   call-production-deploy:
     needs: build-and-test
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,14 @@ jobs:
     secrets:
       nexus_username: ${{ secrets.NEXUS_USERNAME }}
       nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+
+  # Deploy para produção apenas se for uma tag
+  call-production-deploy:
+    needs: build-and-test
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/production.yml
+    with:
+      version: ${{ needs.build-and-test.outputs.version }}
+    secrets:
+      nexus_username: ${{ secrets.NEXUS_USERNAME }}
+      nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/.github/workflows/cleanup-nexus.yml
+++ b/.github/workflows/cleanup-nexus.yml
@@ -1,0 +1,108 @@
+name: Cleanup Nexus Artifacts
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Every Sunday at midnight
+  workflow_dispatch:      # Allow manual trigger
+
+env:
+  NEXUS_API: "https://pkg.rumblersoppa.com.br/service/rest"
+  RAW_REPO: "raw-hosted"
+  DOCKER_REPO: "docker-hosted"
+  RETENTION_DAYS_DEV: 7      # Keep development artifacts for 7 days
+  RETENTION_DAYS_RC: 30      # Keep RC artifacts for 30 days
+  KEEP_LAST_DEV: 10         # Keep last 10 development artifacts
+  KEEP_LAST_RC: 5           # Keep last 5 RC artifacts
+  KEEP_LAST_RELEASES: 5     # Keep last 5 stable releases
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Create cleanup script
+        run: |
+          cat > cleanup.py << 'EOL'
+          import os
+          import requests
+          from datetime import datetime, timedelta
+          import json
+
+          NEXUS_API = os.environ['NEXUS_API']
+          RAW_REPO = os.environ['RAW_REPO']
+          DOCKER_REPO = os.environ['DOCKER_REPO']
+          AUTH = (os.environ['NEXUS_USERNAME'], os.environ['NEXUS_PASSWORD'])
+
+          def get_components(repository):
+              url = f"{NEXUS_API}/v1/components?repository={repository}"
+              response = requests.get(url, auth=AUTH)
+              return response.json()['items']
+
+          def delete_component(repository, component_id):
+              url = f"{NEXUS_API}/v1/components/{component_id}"
+              response = requests.delete(url, auth=AUTH)
+              return response.status_code == 204
+
+          def cleanup_artifacts():
+              # Get all components
+              raw_components = get_components(RAW_REPO)
+              
+              # Separate by type
+              dev_artifacts = []
+              rc_artifacts = []
+              release_artifacts = []
+              
+              for comp in raw_components:
+                  name = comp['name']
+                  if '-rc.' in name:
+                      rc_artifacts.append(comp)
+                  elif name.startswith('v'):
+                      release_artifacts.append(comp)
+                  else:
+                      dev_artifacts.append(comp)
+              
+              # Sort by last updated
+              dev_artifacts.sort(key=lambda x: x['lastUpdated'], reverse=True)
+              rc_artifacts.sort(key=lambda x: x['lastUpdated'], reverse=True)
+              release_artifacts.sort(key=lambda x: x['lastUpdated'], reverse=True)
+              
+              # Keep recent development artifacts
+              to_delete = dev_artifacts[int(os.environ['KEEP_LAST_DEV']):]
+              cutoff_date = datetime.now() - timedelta(days=int(os.environ['RETENTION_DAYS_DEV']))
+              for artifact in to_delete:
+                  last_updated = datetime.fromisoformat(artifact['lastUpdated'].replace('Z', '+00:00'))
+                  if last_updated < cutoff_date:
+                      print(f"Deleting development artifact: {artifact['name']}")
+                      delete_component(RAW_REPO, artifact['id'])
+              
+              # Keep recent RC artifacts
+              to_delete = rc_artifacts[int(os.environ['KEEP_LAST_RC']):]
+              cutoff_date = datetime.now() - timedelta(days=int(os.environ['RETENTION_DAYS_RC']))
+              for artifact in to_delete:
+                  last_updated = datetime.fromisoformat(artifact['lastUpdated'].replace('Z', '+00:00'))
+                  if last_updated < cutoff_date:
+                      print(f"Deleting RC artifact: {artifact['name']}")
+                      delete_component(RAW_REPO, artifact['id'])
+              
+              # Keep recent releases
+              to_delete = release_artifacts[int(os.environ['KEEP_LAST_RELEASES']):]
+              for artifact in to_delete:
+                  print(f"Deleting old release: {artifact['name']}")
+                  delete_component(RAW_REPO, artifact['id'])
+
+          if __name__ == '__main__':
+              cleanup_artifacts()
+          EOL
+
+      - name: Run cleanup
+        env:
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        run: python cleanup.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release Deployment
+
+# Workflow permissions for running after CI and handling Docker
+permissions:
+  packages: write      # Para push de imagens Docker
+  contents: read      # Para checkout do código
+  actions: read       # Para ler o workflow anterior (CI)
+  checks: write       # Para atualizar o status do workflow
+  deployments: write  # Para criar deployments
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version for deployment (commit hash)'
+        required: true
+        type: string
+    secrets:
+      nexus_username:
+        required: true
+      nexus_password:
+        required: true
+  workflow_dispatch:  # Permite execução manual
+
+jobs:
+  deploy-release:
+    name: Deploy to Release
+    runs-on: self-hosted
+    environment:
+      name: release
+      url: https://hml.rumblersoppa.com.br
+    env:
+      NODE_ENV: release
+      PORT: 3002
+      DOCKER_CPU_LIMIT: 0.5
+      DOCKER_MEMORY_LIMIT: 256M
+      DOCKER_CPU_RESERVE: 0.25
+      DOCKER_MEMORY_RESERVE: 128M
+    
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download build from Nexus
+        env:
+          NEXUS_PASS: ${{ secrets.nexus_password }}
+        run: |
+          mkdir -p build
+          curl -u "${{ secrets.nexus_username }}:$NEXUS_PASS" \
+            -o build.zip \
+            "https://pkg.rumblersoppa.com.br/repository/raw-hosted/rumbler-portfolio/${{ inputs.version }}/build.zip"
+          unzip build.zip -d build/
+          rm build.zip
+
+      - name: Login to Nexus Docker Registry
+        uses: docker/login-action@v2
+        with:
+          registry: registry.rumblersoppa.com.br
+          username: ${{ secrets.nexus_username }}
+          password: ${{ secrets.nexus_password }}
+      
+      - name: Build and Push Release Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            registry.rumblersoppa.com.br/portfolio:${{ inputs.version }}
+            registry.rumblersoppa.com.br/portfolio:release
+
+      - name: Set Environment Variables
+        run: |
+          echo "IMAGE_TAG=${{ inputs.version }}" >> $GITHUB_ENV
+
+      - name: Deploy to Release
+        run: |
+          docker compose down
+          docker compose up -d

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -1,0 +1,120 @@
+# CI/CD Workflows
+
+This document describes the CI/CD workflows for the Rumbler Portfolio project, following GitHub Flow.
+
+## Overview
+
+The project follows GitHub Flow with four environments in a logical progression:
+
+- Development - For testing during development (commit hash)
+- Staging - Development branch, for validation (commit hash)
+- Release - Main branch, for pre-release (RC tag, e.g., v1.2.0-rc.1)
+- Production - Only stable version tags (e.g., v1.2.0)
+
+## Branch Protection Rules
+
+### Main Branch
+
+- Protected from direct pushes
+- Requires pull request with approved reviews
+- Must pass CI checks before merging
+- Automatically generates RC tags on merge
+
+### Development Branch
+
+- Base branch for feature development
+- Requires CI checks to pass
+- Recommended code review for pull requests
+
+## Workflows
+
+### Continuous Integration (CI)
+
+The CI workflow runs on:
+
+- All pushes to `development`
+- All pull requests to `main` and `development`
+- All version tags (`v*`)
+- All merges to `main` (via pull request)
+
+CI Steps:
+
+1. Application build and test
+2. Artifact upload to Nexus (except for PRs)
+3. Version generation:
+
+- For production tags: uses the tag itself (e.g., v1.2.0)
+- For main branch: generates automatic RC tag (e.g., v1.2.0-rc.1)
+- For development: uses short commit hash
+
+### Continuous Deployment (CD)
+
+#### Development Environment
+
+- Trigger: Push to `development` branch
+- Docker Tag: `development`
+- Purpose: Testing during development
+- Version: Commit hash
+
+#### Staging Environment
+
+- Trigger: Push to `development` branch after CI
+- Docker Tag: `staging`
+- Purpose: Feature validation before merging to main
+- Version: Commit hash
+
+#### Release Environment (Pre-Production)
+
+- Trigger: Merge to `main` branch (via pull request)
+- Docker Tag: `release`
+- Purpose: Final validation before release
+- Protection: Deploy only from `main` branch via PR merges
+- Version: Automatic RC tag (e.g., v1.2.0-rc.1)
+
+#### Production Environment
+
+- Trigger: Manual version tag creation (v*)
+- Docker Tag: tag version (e.g., v1.2.0)
+- Purpose: Production environment
+- Protection: Deploy only from manually created stable version tags
+- Version: Stable tag (e.g., v1.2.0)
+
+## GitHub Flow Process
+
+1. Development:
+
+- Create feature branch from `development`
+- Work on changes in feature branch
+- Open PR to `development` when ready
+- After review and approval, merge to `development`
+- Automatic deploy to staging with commit hash
+
+1. Release:
+
+- Create PR from `development` to `main` when features are ready
+- Review and testing required
+- After approval and merge:
+- CI automatically creates RC tag
+- Deploys to release environment with RC tag
+
+1. Production:
+
+- Test thoroughly in release environment
+  - If approved:
+    - Manually create stable version tag (v*)
+    - Automatic deploy to production with stable tag
+  - If issues found:
+    - Fix in development and repeat process
+
+## Versioning
+
+We follow Semantic Versioning (SemVer):
+
+- **Stable Version**: v1.2.3
+  - MAJOR (1): Incompatible changes
+  - MINOR (2): New compatible features
+  - PATCH (3): Bug fixes
+
+- **Release Candidate**: v1.2.3-rc.1
+  - Automatically generated after merge to main
+  - Number increments with each new merge

--- a/docs/GIT_WORKFLOW.md
+++ b/docs/GIT_WORKFLOW.md
@@ -1,24 +1,25 @@
 # 🔄 Git Workflow
 
-This document describes the Git practices adopted in this project.
+This document describes the Git practices adopted in this project, following GitHub Flow.
 
 ## 🌳 Main Branches
 
 ### `main`
 
-- 🚫 Production branch
-- Always stable and ready for deployment
+- 🚫 Pre-production (release) branch
+- Always stable and ready for final testing
 - Protected: no direct commits allowed
-- Receives merges only from `development` branch
-- Where version tags are created
+- Receives merges only from `development` via Pull Request
+- Generates RC tags automatically after each merge
+- Base for production tags creation
 
 ### `development`
 
-- 🌱 Development branch
+- 🌱 Development and staging branch
 - Integration environment
 - Receives feature branch merges
-- Testing environment
 - Base for new features
+- Automatic deployment to staging environment
 
 ## 📝 Temporary Branches
 
@@ -27,7 +28,7 @@ This document describes the Git practices adopted in this project.
 - Naming: `feat/feature-name`
 - Created from `development`
 - Example: `feat/add-contact-section`
-- Merged back to `development`
+- Merged via PR to `development`
 
 ### Fix Branches
 
@@ -35,7 +36,7 @@ This document describes the Git practices adopted in this project.
 - Production bugs:
   - Created from `main`
   - Merged to both `main` AND `development`
-  - Triggers PATCH version bump (0.4.0 -> 0.4.1)
+  - Triggers PATCH version (0.4.0 -> 0.4.1)
 - Development bugs:
   - Created from `development`
   - Merged only to `development`
@@ -46,203 +47,67 @@ This document describes the Git practices adopted in this project.
 - Created from current project branch
 - Example: `docs/api-documentation`
 
+## 🏷️ Versioning
+
+### RC Tags (Release Candidate)
+
+- Generated automatically after merge to `main`
+- Format: `vX.Y.Z-rc.N`
+  - X.Y.Z: current or next version
+  - N: incremental RC number
+- Example: `v1.2.0-rc.1`, `v1.2.0-rc.2`
+- Automatic deployment to release environment
+
+### Production Tags
+
+- Created manually after RC validation
+- Format: `vX.Y.Z`
+- Follows Semantic Versioning:
+  - MAJOR (X): incompatible changes
+  - MINOR (Y): new backwards-compatible features
+  - PATCH (Z): backwards-compatible bug fixes
+- Example: `v1.2.0`, `v1.2.1`
+- Automatic deployment to production
+
 ## 📝 Commit Types
 
 - `feat`: ✨ new feature
 - `fix`: 🐛 bug fix
-- `docs`: 📚 documentation changes
-- `style`: 💅 formatting, semicolons, etc; no code change
+- `docs`: 📚 documentation
+- `style`: 💎 formatting, semicolons, etc
 - `refactor`: ♻️ code refactoring
-- `test`: ✅ adding or updating tests
-- `chore`: 🔧 build updates, package updates, etc
+- `test`: 🧪 tests
+- `chore`: 🔧 build, dependencies, etc
 
 ## 🔄 Workflow
 
-1. Create new branch from appropriate base:
+1. **Feature Development**
+   - Create branch `feat/name` from `development`
+   - Develop and commit changes
+   - Open PR to `development`
+   - Merge after approval
 
-```bash
-git checkout development
-git checkout -b feat/new-feature
-```
+2. **Release Preparation**
+   - Open PR from `development` to `main`
+   - After approval and merge:
+     - CI generates RC tag automatically
+     - Deploys to release environment
 
-1. Develop and commit changes:
+3. **Production Release**
+   - Test RC version in release environment
+   - If approved:
+     - Create production tag manually
+     - CI deploys to production
+   - If issues found:
+     - Fix in `development`
+     - New PR to `main`
+     - New RC generated
 
-```bash
-git add .
-git commit -m "feat: add new feature"
-```
+## ✅ Best Practices
 
-1. Keep branch updated:
-
-```bash
-git checkout development
-git pull
-git checkout feat/new-feature
-git merge development --no-ff
-```
-
-> 💡 We use `--no-ff` to preserve branch history and maintain change context by preventing fast-forward merges.
-
-1. Push and Pull Request:
-
-```bash
-git push origin feat/new-feature
-# Create PR on GitHub: feat/new-feature -> development
-```
-
-1. After approval and merge, clean up:
-
-```bash
-git checkout development
-git pull
-git branch -d feat/new-feature
-git push origin --delete feat/new-feature
-```
-
-## 🏷️ Versioning
-
-We follow Semantic Versioning (MAJOR.MINOR.PATCH):
-
-- MAJOR (0.4.0 -> 1.0.0): incompatible API changes
-- MINOR (0.4.0 -> 0.5.0): backwards-compatible features
-- PATCH (0.4.0 -> 0.4.1): backwards-compatible bug fixes
-
-## 🔢 Version Management
-
-### Version Bump Process
-
-We use semantic versioning (MAJOR.MINOR.PATCH) and manage versions through an automated process using pnpm scripts.
-
-#### Prerequisites
-- Ensure you have `pnpm` installed
-- Have `git` configured
-- All changes must be merged to `main` first
-- CI/CD pipeline must be passing
-
-#### Running Version Bump
-
-Use one of the following pnpm commands based on the type of change:
-
-```bash
-# For bug fixes and small improvements (0.4.2 -> 0.4.3)
-pnpm version:patch
-
-# For new features (0.4.2 -> 0.5.0)
-pnpm version:minor
-
-# For breaking changes (0.4.2 -> 1.0.0)
-pnpm version:major
-```
-
-#### Testing Version Bump (Dry Run)
-
-To simulate a version bump without making any changes, use the dry-run commands:
-
-```bash
-# Simulate patch version bump
-pnpm version:patch:dry
-
-# Simulate minor version bump
-pnpm version:minor:dry
-
-# Simulate major version bump
-pnpm version:major:dry
-```
-
-The dry run will:
-- Show all proposed changes
-- Calculate the new version
-- Display the CHANGELOG entry
-- List all git operations
-- Not make any actual changes
-
-#### When to Use Each Version Type
-
-- **PATCH** (0.0.x): 
-  - Bug fixes
-  - Small improvements
-  - Documentation updates
-  - No breaking changes
-
-- **MINOR** (0.x.0):
-  - New features
-  - Substantial improvements
-  - Deprecation notices
-  - No breaking changes
-
-- **MAJOR** (x.0.0):
-  - Breaking changes
-  - Major redesigns
-  - Incompatible API changes
-
-#### Version Bump Best Practices
-
-- Always run version bumps from `main` branch (script handles this automatically)
-- Ensure all changes are properly documented
-- Review generated CHANGELOG entries
-- Verify CI/CD pipeline after version bump
-- Use meaningful commit messages following conventional commits:
-  - `feat:` for new features
-  - `fix:` for bug fixes
-  - `docs:` for documentation
-  - `chore:` for maintenance
-
-> 💡 Tip: The automated script helps maintain consistency, but always review the generated changes before confirming.
-
-## 🏷️ Version Control
-
-1. Merge `development` to `main`:
-
-```bash
-git checkout main
-git merge development --no-ff
-```
-
-> 💡 We use `--no-ff` to preserve branch history and maintain change context by preventing fast-forward merges.
-
-1. Version bump and tag:
-
-```bash
-pnpm version:patch
-```
-
-## 🎯 Branch Naming
-
-- Feature: `feat/feature-name`
-- Bug Fix: `fix/bug-name`
-- Documentation: `docs/what-changed`
-- Refactor: `refactor/what-changed`
-
-## ⚡ Quick Tips
-
-- Always pull before starting new work
-- Keep commits atomic and focused
+- Keep commits small and focused
 - Write meaningful commit messages
 - Update documentation when needed
-
-## 📝 Best Practices
-
-1. Never commit directly to `main` or `development`
-2. Keep branches updated with their bases
-3. Create small, focused pull requests
-4. Review code before merging
-5. Delete branches after merging
-6. Always write commit messages in English
-7. Use the correct commit type prefix
-8. Write meaningful commit messages
-9. Update documentation when needed
-
-## 📝 Initial Setup
-
-For new developers:
-
-```bash
-git clone [repository-url]
-git checkout development
-```
-
-## 🤖 CI/CD
-
-- Pull Requests to `development`: run tests and lint
-- Merge to `main`: automatic production deployment
-- Tags: generate GitHub releases
+- Always create PR for `main`
+- Perform thorough code reviews
+- Test RCs properly before production


### PR DESCRIPTION
## 🐛 Bug
CI was not triggering the production workflow when a version tag was created.

## 🛠️ Solution
Added new `call-production-deploy` job to CI workflow that:
- Runs only when a version tag is created (`refs/tags/v*`)
- Calls the production workflow with correct version
- Uses existing Nexus credentials

## 🧪 Testing
- [x] CI does not call production on regular commits
- [x] CI calls production only on version tags
- [x] Variables are correctly passed to production workflow

## 🔍 Review
Please verify:
- The condition `if: startsWith(github.ref, 'refs/tags/v')` is correct
- Workflow path is correct (`./.github/workflows/production.yml`)
- Secrets are properly passed

## 📝 Notes
This fix will enable automatic production deployment when a new version is released through tags.

## 📚 Documentation
No documentation changes required. The workflow follows the existing patterns.