### PR TITLE
fix(docker): ensure unique container names across environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   app:
     image: registry.rumblersoppa.com.br/portfolio:${IMAGE_TAG:-dev}
-    container_name: rumbler-portfolio-${NODE_ENV:-production}
+    container_name: rumbler-portfolio-${NODE_ENV:-production}-${IMAGE_TAG:-dev}
     restart: unless-stopped
     ports:
       - "${PORT:-3000}:3000"


### PR DESCRIPTION
## Description
Add IMAGE_TAG to container name to prevent conflicts when running multiple environments on the same host.

## Changes
- Modified docker-compose.yml to include IMAGE_TAG in container name
- This ensures each environment (dev, release, prod) has a unique container name

## Testing
- [ ] Test container creation in development environment
- [ ] Test container creation in release environment
- [ ] Test container creation in production environment