### PR TITLE
fix: improve CD workflows configuration

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -12,16 +12,16 @@ on:
       - "development"
 
 permissions:
-  packages: write      # Para push de imagens Docker
-  contents: read      # Para checkout do código
-  actions: read       # Para ler o workflow anterior
-  checks: write       # Para atualizar o status
-  deployments: write  # Para criar deployments
+  packages: write
+  contents: read
+  actions: read
+  checks: write  
+  deployments: write
 
 jobs:
   deploy-development:
     name: Deploy to Development
-    if: github.event.push.branch == 'development'
+    if: github.ref == 'refs/heads/development'
     runs-on: self-hosted
     environment: development
     env:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,14 +9,14 @@ on:
         type: string
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
 
 permissions:
-  packages: write      # Para push de imagens Docker
-  contents: read      # Para checkout do código
-  actions: read       # Para ler o workflow anterior
-  checks: write       # Para atualizar o status
-  deployments: write  # Para criar deployments
+  packages: write
+  contents: read
+  actions: read
+  checks: write
+  deployments: write
 
 jobs:
   deploy-production:
@@ -41,24 +41,17 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
-      - name: Get RC tag
-        id: rc_tag
-        run: |
-          VERSION=${{ github.event.inputs.version || steps.get_version.outputs.version }}
-          RC_TAG="${VERSION%-*}-rc.$(git rev-parse --short HEAD)"
-          echo "rc_tag=${RC_TAG}" >> $GITHUB_OUTPUT
-      
       - name: Download build from Nexus
         env:
           NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
           NEXUS_URL: ${{ secrets.NEXUS_URL }}
           NEXUS_REPO: ${{ secrets.NEXUS_REPOSITORY }}
-          RC_TAG: ${{ steps.rc_tag.outputs.rc_tag }}
+          VERSION: ${{ github.event.inputs.version || steps.get_version.outputs.version }}
         run: |
           mkdir -p build
           curl -u "${{ secrets.NEXUS_USERNAME }}:$NEXUS_PASS" \
             -o build.zip \
-            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/${RC_TAG}/build.zip"
+            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/${VERSION}/build.zip"
           unzip build.zip -d build/
 
       - name: Build and push Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ on:
       - "main"
 
 permissions:
-  packages: write      # Para push de imagens Docker
-  contents: write     # Para checkout do código e criar tags
-  actions: read       # Para ler o workflow anterior
-  checks: write       # Para atualizar o status
-  deployments: write  # Para criar deployments
+  packages: write
+  contents: write
+  actions: read
+  checks: write
+  deployments: write
 
 jobs:
   deploy-release:


### PR DESCRIPTION
## Changes

### Production Workflow
- Update tag pattern to strictly match semantic versions (`v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}`)
  - Now only accepts version numbers between 0-999
  - Prevents any additional characters after version number
  - Examples: ✅ v0.0.1, v1.0.0, v999.999.999 | ❌ v1000.0.0, v1.0.0-rc.123
- Remove unnecessary RC tag handling
- Simplify artifact download using final version

### Testing
- CI passed successfully
- After merging, we should test the complete flow:
  1. Push to `development` -> Deploy to development environment
  2. Push to `main` -> Deploy to release environment with RC tag
  3. Create version tag (e.g., v1.0.0) -> Deploy to production environment