### PR TITLE
fix: add development branch to CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Continuous Integration
 on:
   push:
     branches: 
+      - "development"
       - "feat/**"
       - "fix/**"
       - "docs/**"


### PR DESCRIPTION
## Changes

- Added `development` branch to CI workflow trigger on push

## Why

- Currently, when a PR is merged to development, the CD workflow fails because it can't find the build artifact
- This happens because the CI workflow doesn't run on pushes to development
- By adding development to the trigger, we ensure that CI runs and generates artifacts after PRs are merged

## Testing

- After merging this PR, future merges to development should:
  1. Trigger CI to build and upload artifact
  2. Then trigger CD to download and deploy that artifact