### PR TITLE
fix: adjust workflows to use environment-specific artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Set Version and Environment
       id: version
       run: |
-        if [[ $GITHUB_EVENT_NAME == 'pull_request_target' && ${{ github.event.pull_request.merged }} == true ]]; then
+        if [[ $GITHUB_EVENT_NAME == 'pull_request_target' && "${{ github.event.pull_request.merged }}" == 'true' ]]; then
           # PR foi merged
           if [[ $GITHUB_BASE_REF == 'development' ]]; then
             # PR merged na development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: Continuous Integration
 on:
   push:
     branches: 
-      - "development"
       - "feat/**"
       - "fix/**"
       - "docs/**"
@@ -11,8 +10,15 @@ on:
       - "refactor/**"
       - "test/**"
       - "chore/**"
+    tags:
+      - 'v*'  
   pull_request:
     branches: 
+      - "development"
+      - "main"
+  pull_request_target:
+    types: [closed]
+    branches:
       - "development"
       - "main"
 
@@ -21,6 +27,7 @@ jobs:
     runs-on: self-hosted
     outputs:
       version: ${{ steps.version.outputs.version }}
+      environment: ${{ steps.version.outputs.environment }}
 
     steps:
     - uses: actions/checkout@v4
@@ -43,29 +50,51 @@ jobs:
       run: pnpm test
 
     - name: Build
+      run: pnpm build
+
+    - name: Set Version and Environment
+      id: version
       run: |
-        pnpm build
+        if [[ $GITHUB_EVENT_NAME == 'pull_request_target' && ${{ github.event.pull_request.merged }} == true ]]; then
+          # PR foi merged
+          if [[ $GITHUB_BASE_REF == 'development' ]]; then
+            # PR merged na development
+            VERSION=$(git rev-parse --short HEAD)
+            ENVIRONMENT="development"
+          elif [[ $GITHUB_BASE_REF == 'main' ]]; then
+            # PR merged na main -> release
+            VERSION="v$(git rev-parse --short HEAD)"
+            ENVIRONMENT="release"
+          fi
+        elif [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == refs/tags/* ]]; then
+          # Push de tag -> production
+          VERSION=${GITHUB_REF#refs/tags/}
+          ENVIRONMENT="production"
+        else
+          # Outros casos - não fazemos upload
+          VERSION=$(git rev-parse --short HEAD)
+          ENVIRONMENT="none"
+        fi
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
+
+    # Upload to Nexus apenas nos casos específicos
+    - name: Create and Upload Artifact
+      if: |
+        (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.base_ref == 'development') ||
+        (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.base_ref == 'main') ||
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+      env:
+        NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
+        NEXUS_URL: ${{ secrets.NEXUS_URL }}
+        NEXUS_REPO: ${{ secrets.NEXUS_REPOSITORY }}
+      run: |
+        # Create zip
         cd build
         zip -r ../build.zip .
         cd ..
-
-    - name: Set Version
-      id: version
-      run: |
-        if [[ $GITHUB_REF == refs/pull/* ]]; then
-          PR_NUMBER=$(echo $GITHUB_REF | cut -d / -f 3)
-          VERSION="pr-${PR_NUMBER}-$(git rev-parse --short HEAD)"
-        else
-          VERSION=$(git rev-parse --short HEAD)
-        fi
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-    # Upload to Nexus except for PRs to main
-    - name: Upload to Nexus
-      if: github.base_ref != 'main'
-      env:
-        NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
-      run: |
+        
+        # Upload to Nexus
         curl -u "${{ secrets.NEXUS_USERNAME }}:$NEXUS_PASS" \
           --upload-file build.zip \
-          "https://pkg.rumblersoppa.com.br/repository/raw-hosted/rumbler-portfolio/${{ steps.version.outputs.version }}/build.zip"
+          "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/${{ steps.version.outputs.environment }}/${{ steps.version.outputs.version }}.zip"

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -7,7 +7,8 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-  push:
+  pull_request_target:
+    types: [closed]
     branches:
       - "development"
 
@@ -21,7 +22,7 @@ permissions:
 jobs:
   deploy-development:
     name: Deploy to Development
-    if: github.ref == 'refs/heads/development'
+    if: github.event.pull_request.merged == true
     runs-on: self-hosted
     environment: development
     env:
@@ -34,12 +35,14 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
       - name: Get version from commit
         id: get_version
         run: |
           COMMIT_SHA=${{ github.sha }}
-          VERSION="commit-${COMMIT_SHA:0:7}"
+          VERSION="${COMMIT_SHA:0:7}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
       
       - name: Download build from Nexus
@@ -47,12 +50,12 @@ jobs:
           NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
           NEXUS_URL: ${{ secrets.NEXUS_URL }}
           NEXUS_REPO: ${{ secrets.NEXUS_REPOSITORY }}
-          VERSION: ${{ github.event.inputs.version || steps.get_version.outputs.version }}
         run: |
           mkdir -p build
+          VERSION=${{ github.event.inputs.version || steps.get_version.outputs.version }}
           curl -u "${{ secrets.NEXUS_USERNAME }}:$NEXUS_PASS" \
             -o build.zip \
-            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/${VERSION}/build.zip"
+            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/development/${VERSION}.zip"
           unzip build.zip -d build/
 
       - name: Build and push Docker image

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,7 +9,7 @@ on:
         type: string
   push:
     tags:
-      - 'v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
+      - 'v*'
 
 permissions:
   packages: write
@@ -21,6 +21,7 @@ permissions:
 jobs:
   deploy-production:
     name: Deploy to Production
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: self-hosted
     environment: production
     env:
@@ -33,12 +34,14 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       
-      - name: Get version from tag if not provided
+      - name: Get version from tag
         if: github.event.inputs.version == ''
         id: get_version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${GITHUB_REF#refs/tags/v}  # Remove o prefixo 'refs/tags/v'
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Download build from Nexus
@@ -46,12 +49,12 @@ jobs:
           NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
           NEXUS_URL: ${{ secrets.NEXUS_URL }}
           NEXUS_REPO: ${{ secrets.NEXUS_REPOSITORY }}
-          VERSION: ${{ github.event.inputs.version || steps.get_version.outputs.version }}
         run: |
           mkdir -p build
+          TAG=${GITHUB_REF#refs/tags/}
           curl -u "${{ secrets.NEXUS_USERNAME }}:$NEXUS_PASS" \
             -o build.zip \
-            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/${VERSION}/build.zip"
+            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/production/${TAG}.zip"
           unzip build.zip -d build/
 
       - name: Build and push Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,14 @@ on:
         description: 'Version to deploy'
         required: true
         type: string
-  push:
+  pull_request_target:
+    types: [closed]
     branches:
       - "main"
 
 permissions:
   packages: write
-  contents: write
+  contents: read
   actions: read
   checks: write
   deployments: write
@@ -21,7 +22,7 @@ permissions:
 jobs:
   deploy-release:
     name: Deploy to Release
-    if: github.ref == 'refs/heads/main'
+    if: github.event.pull_request.merged == true
     runs-on: self-hosted
     environment: release
     env:
@@ -37,57 +38,48 @@ jobs:
         with:
           fetch-depth: 0
       
-      - name: Create RC tag
-        id: create_tag
+      - name: Get version from commit
+        if: github.event.inputs.version == ''
+        id: get_version
         run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          COMMIT_HASH=$(git rev-parse --short HEAD)
-          VERSION="${LAST_TAG%-*}-rc.${COMMIT_HASH}"
-          git tag $VERSION
-          git push origin $VERSION
+          COMMIT_SHA=${{ github.sha }}
+          VERSION="${COMMIT_SHA:0:7}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-      
-      - name: Build from development artifact
+
+      - name: Create Release Tag
+        run: |
+          VERSION=${{ github.event.inputs.version || steps.get_version.outputs.version }}
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+
+      - name: Download build from Nexus
         env:
           NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
           NEXUS_URL: ${{ secrets.NEXUS_URL }}
           NEXUS_REPO: ${{ secrets.NEXUS_REPOSITORY }}
-          DEV_VERSION: "pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}"
         run: |
           mkdir -p build
+          VERSION=${{ github.event.inputs.version || steps.get_version.outputs.version }}
           curl -u "${{ secrets.NEXUS_USERNAME }}:$NEXUS_PASS" \
             -o build.zip \
-            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/${DEV_VERSION}/build.zip"
+            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/release/${VERSION}.zip"
           unzip build.zip -d build/
-
-      - name: Upload RC build to Nexus
-        env:
-          NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
-          NEXUS_URL: ${{ secrets.NEXUS_URL }}
-          NEXUS_REPO: ${{ secrets.NEXUS_REPOSITORY }}
-        run: |
-          cd build
-          zip -r ../rc-build.zip .
-          cd ..
-          curl -u "${{ secrets.NEXUS_USERNAME }}:$NEXUS_PASS" \
-            --upload-file rc-build.zip \
-            "${NEXUS_URL}/repository/${NEXUS_REPO}/${{ github.event.repository.name }}/${{ steps.create_tag.outputs.version }}/build.zip"
 
       - name: Build and push Docker image
         env:
           REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
         run: |
-          VERSION=${{ steps.create_tag.outputs.version }}
-          docker build -t ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION} .
-          docker push ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}
+          VERSION=${{ github.event.inputs.version || steps.get_version.outputs.version }}
+          docker build -t ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}-rc .
+          docker push ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}-rc
           
           # Tag as release
-          docker tag ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION} ${REGISTRY_URL}/${{ github.event.repository.name }}:release
+          docker tag ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}-rc ${REGISTRY_URL}/${{ github.event.repository.name }}:release
           docker push ${REGISTRY_URL}/${{ github.event.repository.name }}:release
 
       - name: Deploy to Release
         env:
-          IMAGE_TAG: ${{ steps.create_tag.outputs.version }}
+          IMAGE_TAG: ${{ github.event.inputs.version || steps.get_version.outputs.version }}
         run: |
           # Pull new image first
           docker compose -f docker-compose.yml -f docker-compose.release.yml pull


### PR DESCRIPTION
## What changed
- Modified CI workflow to use environment-specific artifact paths:
  - Development: `development/[hash].zip`
  - Release: `release/[hash].zip`
  - Production: `production/[tag].zip`
- Fixed PR merge condition in CI workflow

## Why
- Each environment should have its own dedicated artifact
- Improves traceability and separation between environments
- Makes rollbacks and debugging easier

## How to test
1. Merge this PR to development
2. Create a PR from development to main
3. After merge to main, verify RC tag creation
4. Create a production tag
5. Verify artifacts are created in correct paths in Nexus for each step