### PR TITLE
fix: add CI workflow dependency to development CD

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -1,8 +1,10 @@
 name: Development CD
 
 on:
-  pull_request_target:
-    types: [closed]
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
     branches:
       - "development"
 
@@ -16,7 +18,9 @@ permissions:
 jobs:
   deploy-development:
     name: Deploy to Development
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'development'
     runs-on: self-hosted
     environment: development
     env:


### PR DESCRIPTION
Changed development CD workflow to wait for CI completion before starting deployment:

- Changed trigger to workflow_run instead of pull_request_target
- Added condition to check if CI was successful
- Ensures deployment only happens with artifacts from development branch