### PR TITLE
fix: remove development from CI push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   # CI com upload: RC tags e Production tags
   push:
     branches: 
+      - "development"
       - "feat/**"
       - "fix/**"
       - "docs/**"


### PR DESCRIPTION
Removed development branch from push trigger to maintain the upload rules:

- CI without upload: push on feature branches and open PRs
- CI with upload: only on merged PRs (via pull_request_target) and tags