### PR TITLE
fix: adjust CD workflow conditions to check base branch

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -20,7 +20,8 @@ jobs:
     name: Deploy to Development
     if: |
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'development'
+      (github.event.workflow_run.base_repository.full_name == github.repository) &&
+      contains(fromJson('["development", "main"]'), github.event.workflow_run.base_branch)
     runs-on: self-hosted
     environment: development
     env:


### PR DESCRIPTION
Fixed CD workflow not running after CI completion by:

1. Removing strict head_branch check
2. Adding base_repository verification
3. Adding base_branch check for development/main

This ensures the CD will run after successful CI completion, regardless of the original feature branch name.