### PR TITLE
fix: adjust CI workflow to handle development push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: Continuous Integration
 
 on:
   # CI sem upload: push em branches de feature e PRs abertas
-  # CI com upload: RC tags e Production tags
+  # CI com upload: RC tags, Production tags e push em development
   push:
     branches: 
-      - "development"
-      - "feat/**"
+      - "development"  # CI com upload
+      - "feat/**"     # CI sem upload
       - "fix/**"
       - "docs/**"
       - "style/**"
@@ -56,13 +56,11 @@ jobs:
     - name: Build
       run: pnpm build
 
-    # Criar zip e fazer upload apenas se for PR merged ou tag
+    # Criar zip e fazer upload apenas se for PR merged, tag ou push em development
     - name: Create build artifact
       if: |
         (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v*-rc.*')) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v[0-9]*.[0-9]*.[0-9]*'))
+        (github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')))
       run: |
         cd build
         zip -r ../build.zip .
@@ -72,9 +70,7 @@ jobs:
       id: version
       if: |
         (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v*-rc.*')) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v[0-9]*.[0-9]*.[0-9]*'))
+        (github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')))
       run: |
         if [[ $GITHUB_EVENT_NAME == 'pull_request_target' && "${{ github.event.pull_request.merged }}" == 'true' ]]; then
           if [[ $GITHUB_BASE_REF == 'development' ]]; then
@@ -84,12 +80,17 @@ jobs:
             VERSION="v$(git rev-parse --short HEAD)"
             ENVIRONMENT="release"
           fi
-        elif [[ $GITHUB_EVENT_NAME == 'push' && $GITHUB_REF == refs/tags/* ]]; then
-          VERSION=${GITHUB_REF#refs/tags/}
-          if [[ $VERSION == *-rc.* ]]; then
-            ENVIRONMENT="release-candidate"
-          else
-            ENVIRONMENT="production"
+        elif [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+          if [[ $GITHUB_REF == 'refs/heads/development' ]]; then
+            VERSION=$(git rev-parse --short HEAD)
+            ENVIRONMENT="development"
+          elif [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+            if [[ $VERSION == *-rc.* ]]; then
+              ENVIRONMENT="release-candidate"
+            else
+              ENVIRONMENT="production"
+            fi
           fi
         fi
         echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -98,9 +99,7 @@ jobs:
     - name: Upload to Nexus
       if: |
         (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v*-rc.*')) ||
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v[0-9]*.[0-9]*.[0-9]*'))
+        (github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')))
       env:
         NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
         NEXUS_URL: ${{ secrets.NEXUS_URL }}


### PR DESCRIPTION
Fixed CI/CD pipeline by adjusting CI workflow to handle development push events:

1. Added development branch to CI push triggers with upload
2. Simplified tag version logic
3. Added specific handling for development push events

This ensures that:
- CI runs and uploads artifacts when PRs are merged to development
- CD can then pick up these artifacts and deploy them