### PR TITLE
fix: update docker image name in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: registry.rumblersoppa.com.br/portfolio:${IMAGE_TAG:-dev}
+    image: registry.rumblersoppa.com.br/rumbler-portfolio:${IMAGE_TAG:-dev}
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
- Corrige o nome da imagem no docker-compose.yml para `rumbler-portfolio`
- Remove a variável `REGISTRY_URL` do docker-compose.yml e usa o valor hardcoded