### PR TITLE
fix: update workflows and docker configurations

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -9,7 +9,7 @@ on:
         type: string
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
 
 permissions:
   packages: write
@@ -60,19 +60,30 @@ jobs:
       - name: Build and push Docker image
         env:
           REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
         run: |
+          # Login no Docker Registry
+          echo "$NEXUS_PASS" | docker login $REGISTRY_URL -u "$NEXUS_USERNAME" --password-stdin
+          
           VERSION=${{ github.event.inputs.version || steps.get_version.outputs.version }}
-          docker build -t ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION} .
-          docker push ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}
+          docker build -t ${REGISTRY_URL}/rumbler-portfolio:${VERSION} .
+          docker push ${REGISTRY_URL}/rumbler-portfolio:${VERSION}
           
           # Tag as latest
-          docker tag ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION} ${REGISTRY_URL}/${{ github.event.repository.name }}:latest
-          docker push ${REGISTRY_URL}/${{ github.event.repository.name }}:latest
+          docker tag ${REGISTRY_URL}/rumbler-portfolio:${VERSION} ${REGISTRY_URL}/rumbler-portfolio:latest
+          docker push ${REGISTRY_URL}/rumbler-portfolio:latest
 
       - name: Deploy to Production
         env:
           IMAGE_TAG: ${{ github.event.inputs.version || steps.get_version.outputs.version }}
+          REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
         run: |
+          # Login no Docker Registry
+          echo "$NEXUS_PASS" | docker login $REGISTRY_URL -u "$NEXUS_USERNAME" --password-stdin
+          
           # Pull new image first
           docker compose -f docker-compose.yml -f docker-compose.production.yml pull
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,7 @@
 name: Release CD
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Version to deploy'
-        required: true
-        type: string
-  pull_request_target:
-    types: [closed]
+  push:
     branches:
       - "main"
 
@@ -22,7 +15,7 @@ permissions:
 jobs:
   deploy-release:
     name: Deploy to Release
-    if: github.event.pull_request.merged == true
+    if: github.ref == 'refs/heads/main'
     runs-on: self-hosted
     environment: release
     env:
@@ -68,14 +61,19 @@ jobs:
       - name: Build and push Docker image
         env:
           REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
         run: |
+          # Login no Docker Registry
+          echo "$NEXUS_PASS" | docker login $REGISTRY_URL -u "$NEXUS_USERNAME" --password-stdin
+          
           VERSION=${{ github.event.inputs.version || steps.get_version.outputs.version }}
-          docker build -t ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}-rc .
-          docker push ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}-rc
+          docker build -t ${REGISTRY_URL}/rumbler-portfolio:${VERSION}-rc .
+          docker push ${REGISTRY_URL}/rumbler-portfolio:${VERSION}-rc
           
           # Tag as release
-          docker tag ${REGISTRY_URL}/${{ github.event.repository.name }}:${VERSION}-rc ${REGISTRY_URL}/${{ github.event.repository.name }}:release
-          docker push ${REGISTRY_URL}/${{ github.event.repository.name }}:release
+          docker tag ${REGISTRY_URL}/rumbler-portfolio:${VERSION}-rc ${REGISTRY_URL}/rumbler-portfolio:release
+          docker push ${REGISTRY_URL}/rumbler-portfolio:release
 
       - name: Deploy to Release
         env:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,6 +1,8 @@
+version: '3.8'
+
 services:
   app:
-    image: registry.rumblersoppa.com.br/portfolio:${IMAGE_TAG:-latest}
+    image: ${REGISTRY_URL}/rumbler-portfolio:${IMAGE_TAG:-latest}
     container_name: rumbler-portfolio-${NODE_ENV:-production}-${IMAGE_TAG:-latest}
     restart: unless-stopped
     ports:

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,6 +1,8 @@
+version: '3.8'
+
 services:
   app:
-    image: registry.rumblersoppa.com.br/portfolio:${IMAGE_TAG:-release}
+    image: ${REGISTRY_URL}/rumbler-portfolio:${IMAGE_TAG:-release}
     container_name: rumbler-portfolio-${NODE_ENV:-release}-${IMAGE_TAG:-release}
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Changes

- Add specific tag pattern for production workflow (v[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3})
- Simplify release workflow triggers (only on push to main)
- Add Docker Registry authentication in workflows
- Standardize image name to rumbler-portfolio across all configurations

## Testing

After merging, we should test:
1. Release workflow triggers only on push to main
2. Production workflow triggers only on semantic version tags
3. Docker Registry authentication works in both environments