### PR TITLE
fix: adjust CI conditions to process merges on main via push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,7 @@ jobs:
 
       - name: Create build artifact
         if: |
-          (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-          (github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')))
+          github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         run: |
           cd build
           zip -r ../build.zip .
@@ -52,18 +51,9 @@ jobs:
       - name: Set Version and Environment
         id: version
         if: |
-          (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-          (github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')))
+          github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         run: |
-          if [[ $GITHUB_EVENT_NAME == 'pull_request_target' && "${{ github.event.pull_request.merged }}" == 'true' ]]; then
-            if [[ $GITHUB_BASE_REF == 'development' ]]; then
-              VERSION=$(git rev-parse --short HEAD)
-              ENVIRONMENT="development"
-            elif [[ $GITHUB_BASE_REF == 'main' ]]; then
-              VERSION="v$(git rev-parse --short HEAD)"
-              ENVIRONMENT="release"
-            fi
-          elif [[ $GITHUB_EVENT_NAME == 'push' ]]; then
+          if [[ $GITHUB_EVENT_NAME == 'push' ]]; then
             if [[ $GITHUB_REF == 'refs/heads/development' ]]; then
               VERSION=$(git rev-parse --short HEAD)
               ENVIRONMENT="development"
@@ -74,6 +64,9 @@ jobs:
               else
                 ENVIRONMENT="production"
               fi
+            elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
+              VERSION="v$(git rev-parse --short HEAD)"
+              ENVIRONMENT="release"
             fi
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -81,8 +74,7 @@ jobs:
 
       - name: Upload to Nexus
         if: |
-          (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true) ||
-          (github.event_name == 'push' && (github.ref == 'refs/heads/development' || startsWith(github.ref, 'refs/tags/v')))
+          github.event_name == 'push' && (github.ref == 'refs/heads/development' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
         env:
           NEXUS_PASS: ${{ secrets.NEXUS_PASSWORD }}
           NEXUS_URL: ${{ secrets.NEXUS_URL }}


### PR DESCRIPTION
This PR adjusts the CI workflow conditions to properly process merges on main via push event, since even with branch protection, the event triggered when a PR is merged is 'push'.