### PR TITLE
fix: update version prefix in CI to match CD expectations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
                 ENVIRONMENT="production"
               fi
             elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
-              VERSION="v$(git rev-parse --short HEAD)"
+              VERSION="rc-$(git rev-parse --short HEAD)"
               ENVIRONMENT="release"
             fi
           fi


### PR DESCRIPTION
This PR updates the version prefix in CI workflow from 'v' to 'rc-' when building from main branch to match what the CD workflow expects.