### PR TITLE
Fix: Docker build and PWA manifest improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,23 @@
 # Serve stage
 FROM node:20-alpine
 
+# Install pnpm
+RUN wget -qO /bin/pnpm "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" && chmod +x /bin/pnpm
+
 # Create non-root user
 RUN addgroup -S -g 1001 appgroup && adduser -S -u 1001 -G appgroup appuser
 
 # Set working directory
 WORKDIR /app
 
+# Set up pnpm environment
+ENV PNPM_HOME="/usr/local/share/pnpm"
+ENV PATH="${PNPM_HOME}:${PATH}"
+RUN mkdir -p ${PNPM_HOME}
+
 # Install serve globally and set permissions
-RUN npm install -g serve && \
-    chown -R appuser:appgroup /usr/local/lib/node_modules && \
+RUN pnpm add -g serve && \
+    chown -R appuser:appgroup ${PNPM_HOME} && \
     chown -R appuser:appgroup /usr/local/bin
 
 # Copy pre-built assets from Nexus artifact

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,4 +1,5 @@
 {
+  "id": ".",
   "short_name": "Rumbler Soppa",
   "name": "Rumbler Soppa | DevOps Specialist",
   "icons": [
@@ -51,7 +52,7 @@
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
-  "background_color": "#000000",
+  "background_color": "#ffffff",
   "description": "Portfolio profissional de Rumbler Soppa, Especialista DevOps",
   "categories": ["portfolio", "professional", "technology"],
   "orientation": "any",


### PR DESCRIPTION
This PR includes two main improvements:

1. Docker Build Fixes:
   - Updated Dockerfile to use pnpm binary directly
   - Fixed permissions for global installations
   - Simplified the build process

2. PWA Manifest Updates:
   - Added `id` field to manifest.json to match `start_url`
   - Fixed warning about missing PWA identifier

Testing:
- [x] Docker build succeeds
- [x] Application runs correctly in container
- [x] PWA manifest warning is resolved