### PR TITLE
Fix code scanning alert no. 19: Log injection

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -72,7 +72,7 @@ app.use((req, res, next) => {
 // Endpoint para relatórios CSP
 app.post('/csp-report', express.json({ type: 'application/csp-report' }), (req, res) => {
   try {
-    const sanitizedInput = req.body.cdp.request.info.source.map((src) => src);
+    const sanitizedInput = req.body.cdp.request.info.source.map((src) => src.replace(/\n|\r/g, ""));
     logger.info(`CSP Violation: ${sanitizedInput}`);
     res.status(200).send('CSP Report Received');
   } catch (error) {


### PR DESCRIPTION
Fixes [https://github.com/rumbler/rumbler-portfolio/security/code-scanning/19](https://github.com/rumbler/rumbler-portfolio/security/code-scanning/19)

To fix the problem, we need to sanitize the user input before logging it. Specifically, we should remove any newline characters from the user input to prevent log injection. This can be done using the `String.prototype.replace` method to ensure that no line endings are present in the user input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
